### PR TITLE
Added logic to cancelling fileChooser

### DIFF
--- a/src/main/java/io/github/railroad/objects/AbstractNewFileWindow.java
+++ b/src/main/java/io/github/railroad/objects/AbstractNewFileWindow.java
@@ -25,17 +25,18 @@ public abstract class AbstractNewFileWindow {
 		this.makeWindow();
 	}
 
-	public void fileDialogBox(Stage window) {
+	public boolean fileDialogBox(Stage window) {
 		FileChooser fileChooser = new FileChooser();
 
 		File file = fileChooser.showSaveDialog(window);
 		if (file != null) {
 			filePath = file.getAbsolutePath();
 			this.pathName.setText(filePath);
+			return true;         // Return true if file is created
 		}
 		//TODO make a remembering classpath
 		fileChooser.setInitialDirectory(new File(""));
-
+		return false;            // Return false if "cancel" is selected
 	}
 
 	protected Button saveFile(Stage window) {
@@ -57,9 +58,17 @@ public abstract class AbstractNewFileWindow {
 
 		this.pathName = new Label("File Path");
 
-		Button yesBtn = saveFile(window);
-		fileDialogBox(window);
+		if (fileDialogBox(window)) { // File is successfully created
+			createConfirmationWindow(window);
+		} else {
+			// Do nothing because user has clicked "cancel"
+		}
 
+	}
+
+	// Confirmation window that appears after creating a file
+	private void createConfirmationWindow(Stage window) {
+		Button yesBtn = saveFile(window);
 		VBox layout = new VBox(10);
 		layout.getChildren().addAll(pathName, yesBtn);
 		layout.setAlignment(Pos.CENTER);
@@ -67,6 +76,5 @@ public abstract class AbstractNewFileWindow {
 		Scene scene = new Scene(layout);
 		window.setScene(scene);
 		window.showAndWait();
-
 	}
 }

--- a/src/main/java/io/github/railroad/objects/CreateNewFileWindow.java
+++ b/src/main/java/io/github/railroad/objects/CreateNewFileWindow.java
@@ -11,15 +11,17 @@ public class CreateNewFileWindow extends AbstractNewFileWindow {
 	}
 
 	@Override
-	public void fileDialogBox(Stage window) {
+	public boolean fileDialogBox(Stage window) {
 		FileChooser fileChooser = new FileChooser();
 
 		File file = fileChooser.showSaveDialog(window);
 		if (file != null) {
 			filePath = file.getAbsolutePath();
 			this.pathName.setText(filePath);
+			return true;         // Return true if file is created
 		}
 		fileChooser.setInitialDirectory(new File(""));
+		return false;            // Return false if "cancel" is selected
 	}
 
 }

--- a/src/main/java/io/github/railroad/objects/CreateNewJavaFile.java
+++ b/src/main/java/io/github/railroad/objects/CreateNewJavaFile.java
@@ -20,7 +20,7 @@ public class CreateNewJavaFile extends AbstractNewFileWindow {
 	}
 
 	@Override
-	public void fileDialogBox(Stage window) {
+	public boolean fileDialogBox(Stage window) {
 		FileChooser fileChooser = new FileChooser();
 
 		FileChooser.ExtensionFilter javaFilter = new FileChooser.ExtensionFilter("Java Files", "*.java");
@@ -30,9 +30,10 @@ public class CreateNewJavaFile extends AbstractNewFileWindow {
 		if (file != null) {
 			filePath = file.getAbsolutePath();
 			this.pathName.setText(filePath);
+			return true;         // Return true if file is created
 		}
 		fileChooser.setInitialDirectory(new File(""));
-
+		return false;            // Return false if "cancel" is selected
 	}
 
 	//TODO make it open the file in editor after saving


### PR DESCRIPTION
Before there was an error whenever the fileChooser window was open and the user clicked cancel. I changed the fileDialogBox() function from a void to a boolean to indicate whether the user had pressed save or cancel. If they press cancel then it returns false and the confirmation window is not created. Otherwise if the user presses save then it functions as before.